### PR TITLE
ignore config file when starting docker-bootstrap

### DIFF
--- a/docker-bootstrap.sh
+++ b/docker-bootstrap.sh
@@ -35,6 +35,7 @@ start_daemon() {
 		dockerd \
 			-H ${BOOTSTRAP_SOCK} \
 			-p ${BOOTSTRAP_PID} \
+                        --config-file "" \
 			--iptables=false \
 			--ip-masq=false \
 			--bridge=none \


### PR DESCRIPTION
In newer versions of docker, dockerd use /etc/daemon.json as default config file, and any any conflict between the config file and the command flags will result in an error.

Setting `--config-file ""` will ignore the default config file, and the new daemon can start as expected.